### PR TITLE
Twin valves

### DIFF
--- a/FluidicMachineModel.pro
+++ b/FluidicMachineModel.pro
@@ -90,7 +90,8 @@ HEADERS += \
     fluidicmachinemodel/rules/variabledomain.h \
     fluidicmachinemodel/fluidicmachinemodel.h \
     fluidicmachinemodel/fluidicmachinemodel_global.h \
-    fluidicmachinemodel/machinegraph.h
+    fluidicmachinemodel/machinegraph.h \
+    fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.h
 
 SOURCES += \
     fluidicmachinemodel/fluidicedge/tubeedge.cpp \
@@ -115,4 +116,5 @@ SOURCES += \
     fluidicmachinemodel/rules/equality.cpp \
     fluidicmachinemodel/rules/variabledomain.cpp \
     fluidicmachinemodel/fluidicmachinemodel.cpp \
-    fluidicmachinemodel/machinegraph.cpp
+    fluidicmachinemodel/machinegraph.cpp \
+    fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.cpp

--- a/fluidicmachinemodel/fluidicnode/valvenode.cpp
+++ b/fluidicmachinemodel/fluidicnode/valvenode.cpp
@@ -46,7 +46,7 @@ std::set<int> ValveNode::getValvePossibleValues() {
 }
 
 std::string ValveNode::toText() {
-    std::string name = "V";
+    std::string name = "V_" + std::to_string(containerID);
     std::string vuelta = std::to_string(containerID) + "[label=\"" + name + "\"];";
     return vuelta;
 }

--- a/fluidicmachinemodel/machine_graph_utils/graphrulesgenerator.cpp
+++ b/fluidicmachinemodel/machine_graph_utils/graphrulesgenerator.cpp
@@ -2,6 +2,7 @@
 #include "fluidicmachinemodel/machine_graph_utils/rules_generation/commomrulesoperations.h"
 #include "fluidicmachinemodel/machine_graph_utils/rules_generation/domaingenerator.h"
 #include "fluidicmachinemodel/machine_graph_utils/rules_generation/shortstatepredicategenerator.h"
+#include "fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.h"
 
 GraphRulesGenerator::GraphRulesGenerator(std::shared_ptr<MachineGraph> graph,
                                         short int ratePrecisionInteger,
@@ -14,11 +15,14 @@ GraphRulesGenerator::GraphRulesGenerator(std::shared_ptr<MachineGraph> graph,
         DomainGenerator domains(graph, calculator);
         ShortStatePredicateGenerator predicates(graph, calculator);
 
+        std::shared_ptr<Rule> twinValvesRules = TwinValvesRulesGenerator::generateTwinValvesRules(graph->getTwinsValves(), calculator);
+        std::shared_ptr<Rule> allRules = calculator->andPredicates(std::dynamic_pointer_cast<Predicate>(twinValvesRules), std::dynamic_pointer_cast<Predicate>(predicates.rule));
+
         const std::vector<std::shared_ptr<Rule>> & domainRules = domains.getDomainsRules();
 
         rules.reserve(domainRules.size() + 1);
         rules.insert(rules.begin(), domainRules.begin(), domainRules.end());
-        rules.insert(rules.begin() + domainRules.size(), predicates.rule);
+        rules.insert(rules.begin() + domainRules.size(), allRules);
     } catch (std::exception & e) {
         throw(std::invalid_argument("Impossible to generate rules for graph: " + graph->toString() +
                                     ".Error message: " + std::string(e.what())));

--- a/fluidicmachinemodel/machine_graph_utils/rules_generation/commomrulesoperations.h
+++ b/fluidicmachinemodel/machine_graph_utils/rules_generation/commomrulesoperations.h
@@ -17,12 +17,14 @@
 class DomainGenerator;
 class GraphRulesGenerator;
 class StatePredicateGenerator;
+class TwinValvesRulesGenerator;
 
 class CommomRulesOperations
 {
     friend class DomainGenerator;
     friend class GraphRulesGenerator;
     friend class ShortStatePredicateGenerator;
+    friend class TwinValvesRulesGenerator;
 
 public:
     virtual ~CommomRulesOperations();

--- a/fluidicmachinemodel/machine_graph_utils/rules_generation/shortstatepredicategenerator.cpp
+++ b/fluidicmachinemodel/machine_graph_utils/rules_generation/shortstatepredicategenerator.cpp
@@ -868,7 +868,7 @@ std::shared_ptr<Predicate> ShortStatePredicateGenerator::makeNodeTubesCombinatio
             subtractTubesWithoutLabel(leavingMap, Label::bigger, leavingNonZero, tempLeavingDummy);
 
             if (!leavingNonZero.empty() &&
-                (leavingNonZero.size() + tempLeavingDummy.size() > 1))
+                (leavingNonZero.size() + tempLeavingDummy.size() >= 1))
             {
                 LabelTypeTubeMap labelsNonZeroLeaving = getSubMap(leavingMap, leavingNonZero);
                 std::shared_ptr<Predicate> combinationPredicates =

--- a/fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.cpp
+++ b/fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.cpp
@@ -1,0 +1,30 @@
+#include "twinvalvesrulesgenerator.h"
+
+std::shared_ptr<Rule> TwinValvesRulesGenerator::generateTwinValvesRules(
+        const std::vector<std::unordered_set<int>> & twinValves,
+        std::shared_ptr<CommomRulesOperations> crOperator)
+{
+    std::shared_ptr<Predicate> mainRule = NULL;
+    for(const std::unordered_set<int> & twins : twinValves) {
+
+        std::shared_ptr<Predicate> twinValveRule = NULL;
+
+        auto it = twins.begin();
+        int lastTwinId = *it;
+        ++it;
+
+        for(; it != twins.end(); ++it) {
+            int actualTwinId = *it;
+
+            std::string lastTwinStr = VariableNominator::getValveVarName(lastTwinId);
+            std::string actualTwinStr = VariableNominator::getValveVarName(actualTwinId);
+
+            std::shared_ptr<Predicate> actualEq = crOperator->createEquality(crOperator->getVariable(lastTwinStr),crOperator->getVariable(actualTwinStr));
+            twinValveRule = crOperator->andPredicates(twinValveRule, actualEq);
+
+            lastTwinId = actualTwinId;
+        }
+        mainRule = crOperator->andPredicates(mainRule, twinValveRule);
+    }
+    return mainRule;
+}

--- a/fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.h
+++ b/fluidicmachinemodel/machine_graph_utils/rules_generation/twinvalvesrulesgenerator.h
@@ -1,0 +1,20 @@
+#ifndef TWINVALVESRULESGENERATOR_H
+#define TWINVALVESRULESGENERATOR_H
+
+#include <memory>
+#include <unordered_set>
+#include <vector>
+
+#include "fluidicmachinemodel/machine_graph_utils/variablenominator.h"
+#include "fluidicmachinemodel/machine_graph_utils/rules_generation/commomrulesoperations.h"
+#include "fluidicmachinemodel/rules/rule.h"
+
+#include "fluidicmachinemodel/fluidicmachinemodel_global.h"
+
+class TwinValvesRulesGenerator
+{
+public:
+    static std::shared_ptr<Rule> generateTwinValvesRules(const std::vector<std::unordered_set<int>> & twinValves, std::shared_ptr<CommomRulesOperations> crOperator);
+};
+
+#endif // TWINVALVESRULESGENERATOR_H

--- a/fluidicmachinemodel/machinegraph.cpp
+++ b/fluidicmachinemodel/machinegraph.cpp
@@ -384,6 +384,21 @@ void MachineGraph::finishAllOperations() {
     }
 }
 
+void MachineGraph::setValvesAsTwins(const std::unordered_set<int> & valvesIds) throw(std::invalid_argument) {
+    if (find(twinValves.begin(), twinValves.end(), valvesIds) == twinValves.end()) {
+        bool correct = true;
+        for(auto it = valvesIds.begin(); correct && it != valvesIds.end(); ++it) {
+            correct = (valvesSet.find(*it) != valvesSet.end());
+        }
+
+        if (correct) {
+            twinValves.push_back(valvesIds);
+        } else {
+            throw(std::invalid_argument("MachineGraph::setValvesAsTwins() has received an id thta is not a valve"));
+        }
+    }
+}
+
 const std::vector<std::shared_ptr<MachineGraph>> & MachineGraph::getConnectedComponents() {
     if(!connectedComponentsUpdated) {
         calculateConnectedComponents();

--- a/fluidicmachinemodel/machinegraph.h
+++ b/fluidicmachinemodel/machinegraph.h
@@ -1,6 +1,7 @@
 #ifndef MACHINEGRAPH_H
 #define MACHINEGRAPH_H
 
+#include <algorithm>
 #include <memory>
 #include <stdexcept>
 #include <unordered_set>
@@ -78,6 +79,8 @@ public:
 
     void finishAllOperations();
 
+    void setValvesAsTwins(const std::unordered_set<int> & valvesIds) throw(std::invalid_argument);
+
     inline bool isContainer(int id) const {
         return (isOpenContainer(id) || isCloseContainer(id));
     }
@@ -126,6 +129,10 @@ public:
         return graphPtr->toString();
     }
 
+    const std::vector<std::unordered_set<int>> & getTwinsValves() const {
+        return twinValves;
+    }
+
 protected:
     std::shared_ptr<GraphType> graphPtr;
     bool connectedComponentsUpdated;
@@ -136,6 +143,8 @@ protected:
     std::unordered_set<int> valvesSet;
     std::unordered_set<int> closeContainersSet;
     std::unordered_set<int> openContainersSet;
+
+    std::vector<std::unordered_set<int>> twinValves;
 
     AutoEnumerate luquidIdserie;
     std::unordered_map<short int, short int> openContainerLiquidIdMap;


### PR DESCRIPTION
*) twin valves (group of valves that must share the same position) is now added.
*) corrected a bug in the rules generator that prevent from generating rules for a combination when one tube is not dummy and the rest yes.